### PR TITLE
Upgrade font-setting component and Angular in Settings [stage-2]

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,12 +19,12 @@
     "test"
   ],
   "devDependencies": {
-    "angular-mocks": "~1.3.0",
+    "angular-mocks": "~1.4.x",
     "q": "1.0.1",
     "web-component-tester": "*"
   },
   "dependencies": {
-    "angular": "~1.3.0",
+    "angular": "~1.4.0",
     "angular-bootstrap": "~0.11.1",
     "angular-route": "~1.3.0",
     "moment": "2.11.1",
@@ -32,13 +32,13 @@
     "rv-common-i18n": "https://github.com/Rise-Vision/common-i18n.git#1.3.40",
     "rv-common-style": "https://github.com/Rise-Vision/common-style.git#1.4.7",
     "widget-common": "https://github.com/Rise-Vision/widget-common.git#3.4.4",
-    "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#3.2.2",
+    "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#3.3.0",
     "widget-settings-ui-core": "https://github.com/Rise-Vision/widget-settings-ui-core.git#0.4.2"
   },
   "resolutions": {
-    "angular": "~1.3.0",
+    "angular": "~1.4.0",
     "angular-bootstrap": "^0.13.0",
-    "angular-mocks": "~1.3.0",
+    "angular-mocks": "~1.4.x",
     "angular-sanitize": "~1.3.0",
     "jquery": "~2.1.1",
     "rv-common-style": "1.4.7"

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,10 +30,10 @@
       "./src/widget.html"
     ],
     vendorFiles = [
-      "./src/components/tinymce-dist/plugins/**/*",
-      "./src/components/tinymce-dist/skins/**/*",
-      "./src/components/tinymce-dist/themes/**/*",
-      "./src/components/tinymce-dist/tinymce*.js",
+      "./src/components/tinymce/plugins/**/*",
+      "./src/components/tinymce/skins/**/*",
+      "./src/components/tinymce/themes/**/*",
+      "./src/components/tinymce/tinymce*.js",
       "./src/components/angular/angular*.js",
       "./src/components/angular/*.gzip",
       "./src/components/angular/*.map",
@@ -119,7 +119,8 @@
 // ***** e2e Testing ***** //
 
   gulp.task("html:e2e:settings", factory.htmlE2E({
-    e2emomenttimezone: "components/moment-timezone/builds/moment-timezone-with-data-2010-2020.js"
+    e2emomenttimezone: "components/moment-timezone/builds/moment-timezone-with-data-2010-2020.js",
+    e2eTinymce: "components/tinymce/tinymce.js"
   }));
 
   gulp.task("e2e:server:settings", ["config", "html:e2e:settings"], factory.testServer());

--- a/src/settings.html
+++ b/src/settings.html
@@ -31,15 +31,14 @@
     })(window,document,'FS','script','user');
   </script>
 
-  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.20/angular.min.js"></script>
+  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.14/angular.min.js"></script>
   <!-- if AngularJS fails to load fallback to a local version -->
   <script>window.angular || document.write(unescape("%3Cscript src='js/vendor/angular/angular.min.js' type='text/javascript'%3E%3C/script%3E"));
   </script>
 
-  <script src="//cdn.tinymce.com/4/tinymce.min.js"></script>
-  <!-- if TinyMCE fails to load fallback to a local version -->
-  <script>window.tinymce || document.write(unescape("%3Cscript src='js/vendor/tinymce-dist/tinymce.min.js' type='text/javascript'%3E%3C/script%3E"));
-  </script>
+  <!-- build:e2eTinymce -->
+  <script src="js/vendor/tinymce/tinymce.min.js"></script>
+  <!-- endbuild -->
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.11.2/moment.min.js"></script>
   <!-- if MomentJs fails to load fallback to a local version -->


### PR DESCRIPTION
- Angular upgraded to `1.4.14`
- Using latest widget-settings-ui-components for updated font setting
- Using local version of tinymce via widget-settings-ui-components instead of CDN