### PR TITLE
Use latest moment-timezone package and with data 10 year range

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
     "common-header": "https://github.com/Rise-Vision/common-header.git#v4.0.0",
     "jquery": "~3.3.1",
     "moment": "2.11.1",
-    "moment-timezone": "0.5.0",
+    "moment-timezone": "0.5.33",
     "widget-common": "https://github.com/Rise-Vision/widget-common.git#v3.13.0",
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#3.5.0",
     "widget-settings-ui-core": "https://github.com/Rise-Vision/widget-settings-ui-core.git#0.4.2"

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -129,7 +129,7 @@
 // ***** e2e Testing ***** //
 
   gulp.task("html:e2e:settings", factory.htmlE2E({
-    e2emomenttimezone: "components/moment-timezone/builds/moment-timezone-with-data-2010-2020.js",
+    e2emomenttimezone: "components/moment-timezone/builds/moment-timezone-with-data-10-year-range.js",
     e2eTinymce: "components/tinymce/tinymce.js"
   }));
 
@@ -174,7 +174,7 @@
       "src/components/widget-settings-ui-core/dist/*.js",
       "src/components/bootstrap-form-components/dist/js/**/*.js",
       "src/components/moment/moment.js",
-      "src/components/moment-timezone/builds/moment-timezone-with-data-2010-2020.js",
+      "src/components/moment-timezone/builds/moment-timezone-with-data-10-year-range.js",
       "src/config/version.js",
       "src/config/test.js",
       "src/settings/settings-app.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8704,12 +8704,6 @@
         }
       }
     },
-    "pathval": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
-      "dev": true
-    },
     "pause-stream": {
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
@@ -11997,7 +11991,7 @@
       "requires": {
         "async": "0.9.2",
         "casperjs": "1.1.4",
-        "chai": "4.2.0",
+        "chai": "4.3.4",
         "chai-as-promised": "7.1.1",
         "event-stream": "4.0.1",
         "express": "4.17.1",
@@ -12021,7 +12015,7 @@
         "karma-phantomjs-launcher": "1.0.4",
         "karma-sinon-chai": "2.0.2",
         "karma-webpack": "1.8.1",
-        "lodash": "4.17.20",
+        "lodash": "4.17.21",
         "mocha": "6.2.2",
         "mocha-multi": "1.1.3",
         "mocha-proshot": "1.0.1",
@@ -12085,16 +12079,16 @@
           "dev": true
         },
         "chai": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
-          "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
+          "integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
           "dev": true,
           "requires": {
             "assertion-error": "1.1.0",
             "check-error": "1.0.2",
             "deep-eql": "3.0.1",
             "get-func-name": "2.0.0",
-            "pathval": "1.1.0",
+            "pathval": "1.1.1",
             "type-detect": "4.0.8"
           }
         },
@@ -12243,9 +12237,9 @@
           }
         },
         "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         },
         "log-symbols": {
@@ -12372,6 +12366,12 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "pathval": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+          "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
           "dev": true
         },
         "require-main-filename": {

--- a/src/settings.html
+++ b/src/settings.html
@@ -46,7 +46,7 @@
   </script>
 
   <!-- build:e2emomenttimezone -->
-  <script src="js/vendor/moment-timezone/builds/moment-timezone-with-data-2010-2020.min.js"></script>
+  <script src="js/vendor/moment-timezone/builds/moment-timezone-with-data-10-year-range.js"></script>
   <!-- endbuild -->
 
 </head>

--- a/src/widget.html
+++ b/src/widget.html
@@ -39,7 +39,7 @@
   <script src="components/widget-common/dist/rise-cache.js"></script>
   <script src="components/widget-common/dist/common.js"></script>
   <script src="components/moment/moment.js"></script>
-  <script src="components/moment-timezone/builds/moment-timezone-with-data-2010-2020.js"></script>
+  <script src="components/moment-timezone/builds/moment-timezone-with-data-10-year-range.js"></script>
   <script src="config/version.js"></script>
   <script src="config/config.js"></script>
   <script src="widget/time-date.js"></script>

--- a/test/index.html
+++ b/test/index.html
@@ -16,7 +16,8 @@
     "integration/time-date-default.html",
     "integration/time-date-no-date.html",
     "integration/time-date-no-time.html",
-    "integration/time-date-no-time-and-date.html"
+    "integration/time-date-no-time-and-date.html",
+    "integration/time-date-timezone.html"
   ]);
 </script>
 </body>

--- a/test/integration/time-date-timezone.html
+++ b/test/integration/time-date-timezone.html
@@ -29,7 +29,7 @@
 <script src="../../src/components/widget-common/dist/message.js"></script>
 <script src="../../src/components/widget-common/dist/common.js"></script>
 <script src="../../src/components/moment/moment.js"></script>
-<script src="../../src/components/moment-timezone/builds/moment-timezone-with-data-2010-2020.js"></script>
+<script src="../../src/components/moment-timezone/builds/moment-timezone-with-data-10-year-range.js"></script>
 
 <script src="../../src/widget/main.js"></script>
 


### PR DESCRIPTION
## Description
Use latest `moment-timezone` package 

Target the build `moment-timezone-with-data-10-year-range.js` 

## Motivation and Context
Fixes issue #52 

## How Has This Been Tested?
Locally and with staged widget

Presentation - https://apps.risevision.com/editor/workspace/dcd87fb0-04b6-420a-ac46-ee0384a0586d?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f

Preview - https://widgets.risevision.com/viewer/?type=presentation&id=dcd87fb0-04b6-420a-ac46-ee0384a0586d

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
