### PR TITLE
Prevent processing logs to client-side-events

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
     "jquery": "~3.3.1",
     "moment": "2.11.1",
     "moment-timezone": "0.5.33",
-    "widget-common": "https://github.com/Rise-Vision/widget-common.git#v3.13.0",
+    "widget-common": "https://github.com/Rise-Vision/widget-common.git#v3.14.0",
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#3.5.0",
     "widget-settings-ui-core": "https://github.com/Rise-Vision/widget-settings-ui-core.git#0.4.2"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -920,8 +920,7 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-      "dev": true
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "asn1": {
       "version": "0.2.4",
@@ -8056,7 +8055,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/nodegit-promise/-/nodegit-promise-4.0.0.tgz",
       "integrity": "sha1-VyKxhPLfcycWEGSnkdLoQskWezQ=",
-      "dev": true,
       "requires": {
         "asap": "2.0.6"
       }
@@ -8146,8 +8144,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-component": {
       "version": "0.0.3",
@@ -8703,6 +8700,12 @@
           "dev": true
         }
       }
+    },
+    "pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true
     },
     "pause-stream": {
       "version": "0.0.11",
@@ -11522,8 +11525,21 @@
         "cleankill": "1.0.3",
         "freeport": "1.0.5",
         "launchpad": "0.6.0",
+        "promisify-node": "0.4.0",
         "selenium-standalone": "5.11.2",
         "which": "1.3.1"
+      },
+      "dependencies": {
+        "promisify-node": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/promisify-node/-/promisify-node-0.4.0.tgz",
+          "integrity": "sha1-MoA4dOxBF4TkeGwzmQKoeheaRpw=",
+          "optional": true,
+          "requires": {
+            "nodegit-promise": "4.0.0",
+            "object-assign": "4.1.1"
+          }
+        }
       }
     },
     "wct-sauce": {
@@ -11995,7 +12011,7 @@
         "chai-as-promised": "7.1.1",
         "event-stream": "4.0.1",
         "express": "4.17.1",
-        "glob": "7.1.6",
+        "glob": "7.1.7",
         "gulp": "3.9.1",
         "gulp-coveralls": "0.1.4",
         "gulp-html-replace": "1.6.2",
@@ -12024,7 +12040,7 @@
         "reporter-file": "0.0.1",
         "run-sequence": "0.3.7",
         "sinon": "7.5.0",
-        "sinon-chai": "3.5.0",
+        "sinon-chai": "3.6.0",
         "spawn-cmd": "0.0.2",
         "spec-xunit-file": "0.0.1-3",
         "xml2js": "0.4.23",
@@ -12195,9 +12211,9 @@
           "dev": true
         },
         "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "version": "7.1.7",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -12368,12 +12384,6 @@
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         },
-        "pathval": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-          "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-          "dev": true
-        },
         "require-main-filename": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -12407,9 +12417,9 @@
           }
         },
         "sinon-chai": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.5.0.tgz",
-          "integrity": "sha512-IifbusYiQBpUxxFJkR3wTU68xzBN0+bxCScEaKMjBvAQERg6FnTTc1F17rseLb1tjmkJ23730AXpFI0c47FgAg==",
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.6.0.tgz",
+          "integrity": "sha512-bk2h+0xyKnmvazAnc7HE5esttqmCerSMcBtuB2PS2T4tG6x8woXAxZeJaOJWD+8reXHngnXn0RtIbfEW9OTHFg==",
           "dev": true
         },
         "split": {


### PR DESCRIPTION
## Description
Prevent the flow of processing sending logs to client-side-events project by using latest widget-common. See https://github.com/Rise-Vision/common-template/pull/203 for changes. 

## Motivation and Context
https://github.com/Rise-Vision/widget-common/issues/168

## How Has This Been Tested?
Tested using Charles Proxy to map to local version of common-template and config-prod and ran a schedule on ChrOS player. Validated no logs to `Display_Events.events` were inserted. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
no
